### PR TITLE
fix(chart): Helm 3 validates, error on statefulset

### DIFF
--- a/charts/nsqd/templates/nsqd-statefulset.yaml
+++ b/charts/nsqd/templates/nsqd-statefulset.yaml
@@ -8,8 +8,9 @@ metadata:
     component.deis.io/version: {{ .Values.docker_tag }}
 spec:
   replicas: {{ .Values.replicas }}
-  strategy:
-    type: Recreate
+  serviceName: deis-nsqd
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: deis-nsqd


### PR DESCRIPTION
The deploy in v2.22.2 fails without this change, using Helm 3 on DOK8s 1.19.x